### PR TITLE
Update location for entry 2027 in list_of_ejcs.csv

### DIFF
--- a/resources/list_of_ejcs.csv
+++ b/resources/list_of_ejcs.csv
@@ -47,4 +47,4 @@ issue;year;dates;city;country;latitude;longitude
 46;2024;;Ovar;Portugal;40.8594819;-8.6252174
 47;2025;;Arnhem;Netherlands;51.9796943;5.9116926
 48;2026;;Ptuj;Slovenia;46.4198096;15.8717378
-49;2027;;Bruneck;Italy;46.7963194;11.9355121
+49;2027;;Azores;Portugal;37.8085564;-25.4731374


### PR DESCRIPTION
EJC in Bruneck had to cancel, Azores stepped up to host the EJC 2027, this commit updates the map-data to reflect this change